### PR TITLE
[WIP]: Create separate snpstats build to be integrated with Genesis

### DIFF
--- a/Dockerfile.gmmat
+++ b/Dockerfile.gmmat
@@ -79,6 +79,7 @@ RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 		autoconf \
 		automake \
 		cmake \
+		gcc \
 		g++ \
 		make \
 		r-base-dev \

--- a/Dockerfile.prsice
+++ b/Dockerfile.prsice
@@ -12,7 +12,6 @@ RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 		r-cran-rcolorbrewer \
 	&& \
 	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
-
 # ------------------------------------------------------------------------------
 # BUILDER LAYER
 FROM base as builder
@@ -22,10 +21,12 @@ RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 	--no-install-recommends --no-install-suggests \
 		zlib1g-dev \
 		cmake \
-		g++ \
 		git \
+		g++ \
 		make \
 		r-cran-rcppeigen
+	&& \
+	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
 RUN git clone --depth 1 https://github.com/choishingwan/PRSice.git && \
 	cd PRSice && mkdir build && cd build && cmake ../ && make

--- a/Dockerfile.prsice
+++ b/Dockerfile.prsice
@@ -4,6 +4,7 @@ FROM $BASE as base
 RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 	--no-install-recommends --no-install-suggests \
 		libeigen3-dev \
+		libgzstream0 \
 		libpthread-stubs0-dev \
 		zlib1g \
 		r-cran-data.table \
@@ -19,6 +20,7 @@ FROM base as builder
 # builder only dependencies
 RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 	--no-install-recommends --no-install-suggests \
+		libgzstream-dev \
 		zlib1g-dev \
 		cmake \
 		git \

--- a/Dockerfile.saige
+++ b/Dockerfile.saige
@@ -15,13 +15,17 @@ RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 		zlib1g \
 		gfortran \
 		dpkg-dev \
+		r-cran-bh \
 		r-cran-data.table \
+		r-cran-dplyr \
 		r-cran-lattice \
 		r-cran-matrix \
 		r-cran-optparse \
-		r-cran-rcpp \
-		r-cran-rcppparallel \
+		r-cran-qlcmatrix \
 		r-cran-rhpcblasctl \
+		r-cran-rspectra \
+		r-cran-r.utils \
+		r-bioc-biocversion
 	&& \
 	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
 # ------------------------------------------------------------------------------
@@ -39,16 +43,11 @@ RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 		git \
 		g++ \
 		make \
-		r-cran-biocmanager \
-		r-bioc-biocversion \
-		r-cran-bh \
-		r-cran-dplyr \
-		r-cran-qlcmatrix \
-		r-cran-r.utils \
+		r-cran-rcpp \
 		r-cran-rcpparmadillo \
 		r-cran-rcppeigen \
-		r-cran-rspectra \
-		r-cran-rsqlite
+		r-cran-rcppparallel \
+		r-cran-biocmanager
 
 # pick up remaining bioconductor dependencies not packaged w/ ubuntu 
 RUN \

--- a/Dockerfile.snpstats
+++ b/Dockerfile.snpstats
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0
+ARG BASE_IMAGE
+# ------------------------------------------------------------------------------
+FROM $BASE_IMAGE
+ARG RUN_CMD
+LABEL org.opencontainers.image.description="Genomics Analysis R bioc snpstats"
+
+RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
+	apt -y install --no-install-recommends \
+	r-cran-data.table r-cran-formatr r-cran-futile.logger \
+	r-cran-futile.options r-cran-genetics r-cran-glmnet \
+	r-cran-igraph r-cran-jomo r-cran-lambda.r \
+	r-cran-lmtest r-cran-optparse r-cran-ordinal \
+	r-cran-matrix r-cran-matrixmodels r-cran-mice \
+	r-cran-mitml r-cran-pan r-cran-plogr \
+	r-cran-qqman r-cran-quantreg r-cran-r.utils \
+	r-cran-rcurl r-cran-reshape2 r-cran-rsqlite \
+	r-cran-sandwich r-cran-shape r-cran-snow \
+	r-cran-sparsem r-cran-tidyverse r-cran-ucminf \
+	r-cran-biocmanager r-bioc-biocversion r-bioc-biobase \
+	r-bioc-biocparallel r-bioc-biostrings r-bioc-dnacopy \
+	r-bioc-genomeinfodbdata r-bioc-genomeinfodb r-bioc-genomicranges \
+	r-bioc-iranges r-bioc-s4vectors r-bioc-snpstats \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /tmp/*
+
+ARG TEST="/test.sh"
+COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+# ------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ SIF_IMAGES := $(TOOLS:=_$(DOCKER_TAG).sif)
 IMAGE_TEST := /test.sh
 
 .PHONY: apptainer_clean apptainer_distclean apptainer_test \
-	docker_base docker_clean docker_release $(TOOLS)
+	docker_base docker_clean docker_test docker_release $(TOOLS)
 
 help:
 	@echo "Targets: all build clean test release"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ORG_NAME ?= hihg-um
 OS_BASE ?= ubuntu
 OS_VER ?= 24.04
 
-TOOLS := genesis gmmat prosper prsice saige seqmeta staar
+TOOLS := snpstats genesis gmmat prosper prsice saige seqmeta staar
 
 ifneq ($(IMAGE_REPO),)
     DOCKER_REPO := $(IMAGE_REPO)/$(ORG_NAME)

--- a/src/test/snpstats.sh
+++ b/src/test/snpstats.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+Rscript -e "library('snpStats'); sessionInfo()"


### PR DESCRIPTION
Do not merge, work in progress

This creates an additional container for snpstats.
Based on the commonality with genesis, snpstats
could be used as base image for genesis.

This would require the TOOLS target to be modified,
dropping genesis, and adding a separate genesis target
that specifies the snpstats image as base.

