### PR TITLE
Simplify base build: add ca-certificates; drop cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ FROM $BASE_IMAGE
 ENV TZ="UTC"
 
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
-	apt -y install --no-install-recommends \
-	apt-utils bzip2 curl make \
-	r-base r-base-dev \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& rm -rf /tmp/*
+	apt -y install --no-install-recommends --no-install-suggests \
+	apt-utils bzip2 ca-certificates curl r-base && apt -y clean && \
+	rm -rf /tmp/*
 # ------------------------------------------------------------------------------

--- a/Dockerfile.gmmat
+++ b/Dockerfile.gmmat
@@ -19,23 +19,24 @@ FROM base as builder
 # builder only dependencies
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 	apt -y install --no-install-recommends \
-	libdeflate-dev libzstd-dev liblzma-dev r-cran-remotes \
-	r-cran-biocmanager \
+	gcc libdeflate-dev libzstd-dev liblzma-dev make \
 	r-cran-devtools \
 	r-cran-data.table \
 	r-cran-domc \
 	r-cran-foreach \
 	r-cran-matrix \
 	r-cran-rcpparmadillo \
+	r-cran-remotes \
+	r-bioc-s4vectors \
 	r-cran-testthat \
+	r-cran-biocmanager \
 	r-bioc-biobase \
 	r-bioc-biocgenerics \
 	r-bioc-biocparallel \
 	r-bioc-biostrings \
 	r-bioc-iranges \
 	r-bioc-genomeinfodb \
-	r-bioc-genomicranges \
-	r-bioc-s4vectors && \
+	r-bioc-genomicranges && \
 	rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*
 
 

--- a/Dockerfile.prsice
+++ b/Dockerfile.prsice
@@ -8,17 +8,13 @@ FROM $BASE_IMAGE as builder
 # PRSice currently only compiles on Ubuntu<20.04
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 	apt -y install \
-	cmake git \
-	libpthread-stubs0-dev zlib1g-dev \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& rm -rf /tmp/*
+	cmake g++ git \
+	libeigen3-dev libpthread-stubs0-dev zlib1g-dev
 
 RUN git clone --depth 1 https://github.com/choishingwan/PRSice.git && \
 	cd PRSice && \
-	mkdir build && \
-	cd build && \
-	cmake ../ && \
-	make
+	mkdir build && cd build && \
+	cmake ../ && make
 # ------------------------------------------------------------------------------
 # RUNTIME LAYER
 FROM $BASE_IMAGE as runtime
@@ -27,7 +23,7 @@ ARG RUN_CMD
 # runtime only dependencies
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 	apt -y install --no-install-recommends \
-	r-cran-data.table r-cran-ggplot2 \
+	libeigen3-dev r-cran-data.table r-cran-ggplot2 \
 	r-cran-optparse r-cran-rcolorbrewer \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /tmp/*

--- a/Dockerfile.saige
+++ b/Dockerfile.saige
@@ -7,6 +7,7 @@ FROM $BASE_IMAGE as base
 # shared builder and runtime dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
 	apt-get install -y --no-install-recommends \
+	gfortran \
 	r-cran-data.table r-cran-lattice r-cran-matrix \
 	r-cran-optparse r-cran-rcpp r-cran-rcppparallel \
 	r-cran-rhpcblasctl \
@@ -19,7 +20,7 @@ FROM base as builder
 # builder only dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
 	apt-get install -y --no-install-recommends \
-	cmake git g++ \
+	cmake dpkg-dev git g++ make \
 	liblzma-dev libsavvy-dev libshrinkwrap-dev \
 	libsuperlu-dev libzstd-dev zlib1g-dev \
 	r-cran-biocmanager r-bioc-biocversion r-cran-bh \

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ docker: docker_base $(TOOLS)
 $(TOOLS):
 	@echo "Building Docker container: $(ORG_NAME)/$@:$(DOCKER_TAG)"
 	@docker build \
+		$(DOCKER_BUILD_ARGS) \
 		-f Dockerfile.$@ \
 		-t $(ORG_NAME)/$@:$(DOCKER_TAG) \
-		$(DOCKER_BUILD_ARGS) \
 		--build-arg BASE_IMAGE=$(ORG_NAME)/$(DOCKER_BASE):$(DOCKER_TAG) \
 		--build-arg RUN_CMD=$@ \
 		.


### PR DESCRIPTION
 - updated ca-certificates are needed for any subsequent outgoing SSL connections, these should be standard in any base image
 - don't clean up the sources URI's, since those may be needed by intermediate (builder) images that install dev packages not needed at runtime