### PR TITLE
[WIP] Create separate snpstats build to be integrated with Genesis

### DIFF
--- a/Dockerfile.snpstats
+++ b/Dockerfile.snpstats
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0
+ARG BASE_IMAGE
+# ------------------------------------------------------------------------------
+FROM $BASE_IMAGE
+ARG RUN_CMD
+LABEL org.opencontainers.image.description="Genomics Analysis R bioc snpstats"
+
+RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
+	apt -y install --no-install-recommends \
+	r-cran-data.table r-cran-formatr r-cran-futile.logger \
+	r-cran-futile.options r-cran-genetics r-cran-glmnet \
+	r-cran-igraph r-cran-jomo r-cran-lambda.r \
+	r-cran-lmtest r-cran-optparse r-cran-ordinal \
+	r-cran-matrix r-cran-matrixmodels r-cran-mice \
+	r-cran-mitml r-cran-pan r-cran-plogr \
+	r-cran-qqman r-cran-quantreg r-cran-r.utils \
+	r-cran-rcurl r-cran-reshape2 r-cran-rsqlite \
+	r-cran-sandwich r-cran-shape r-cran-snow \
+	r-cran-sparsem r-cran-tidyverse r-cran-ucminf \
+	r-cran-biocmanager r-bioc-biocversion r-bioc-biobase \
+	r-bioc-biocparallel r-bioc-biostrings r-bioc-dnacopy \
+	r-bioc-genomeinfodbdata r-bioc-genomeinfodb r-bioc-genomicranges \
+	r-bioc-iranges r-bioc-s4vectors r-bioc-snpstats \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /tmp/*
+
+ARG TEST="/test.sh"
+COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+# ------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OS_VER ?= 24.04
 
 IMAGE_REPOSITORY ?=
 
-TOOLS := genesis gmmat prosper prsice saige seqmeta
+TOOLS := snpstats genesis gmmat prosper prsice saige seqmeta
 
 DOCKER_BUILD_ARGS ?=
 DOCKER_TAG ?= $(shell git describe --tags --broken --dirty --all --long | \

--- a/src/test/snpstats.sh
+++ b/src/test/snpstats.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+Rscript -e "library('snpStats'); sessionInfo()"


### PR DESCRIPTION
 - Based on the commonality with genesis, snpstats should be used as base image for genesis.

 - The change would require the TOOLS target to be modified, dropping genesis, and adding a separate genesis target that specifies the snpstats image as base for genesis.