### PR TITLE
Additional label improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,28 @@
 ARG BASE
 FROM $BASE
 
+# build-args
+ARG BASE
+ARG GIT_TAG
+ARG GIT_REV
+ARG BUILD_ARCH
+ARG BUILD_REPO
+ARG BUILD_TIME
+ARG URL_NAME
+
+LABEL org.opencontainers.image.authors="kms309@miami.edu,sxd1425@miami.edu"
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="$BASE"
+LABEL org.opencontainers.image.description="Base Image"
+LABEL org.opencontainers.image.created="$BUILD_TIME"
+LABEL org.opencontainers.image.url="${BUILD_REPO}/${URL_NAME}:${GIT_TAG}-${GIT_REV}_${BUILD_ARCH}"
+LABEL org.opencontainers.image.source="https://github.com/hihg-um/docker-analytics"
+LABEL org.opencontainers.image.version="$GIT_TAG"
+LABEL org.opencontainers.image.revision="$GIT_REV"
+LABEL org.opencontainers.image.vendor="The Hussman Institute for Human Genomics, The University of Miami Miller School of Medicine"
+LABEL org.opencontainers.image.licenses="GPL-3.0"
+LABEL org.opencontainers.image.title="Genomics Analysis Tools in R"
+
 ENV TZ="UTC"
 
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Label consistency and correctness fixes for HIHG containers

 - label build time is UTC
 - shorten repo name to IMAGE_REPO, pre-populate tentatively and pass it to the container build to construct a full URI
 - re-arrange parameters to maintain a clean name space
 - fix BASE_IMAGE tag; replace inadvertent / with :