### PR TITLE
Add container-labels to each build; cleanups

### DIFF
--- a/Dockerfile.genesis
+++ b/Dockerfile.genesis
@@ -3,7 +3,19 @@ ARG BASE
 # ------------------------------------------------------------------------------
 # RUNTIME LAYER
 FROM $BASE
+
+# build-args
+ARG BASE
 ARG RUN_CMD
+ARG GIT_TAG
+ARG GIT_REV
+ARG BUILD_ARCH
+ARG BUILD_REPO
+
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="$BASE"
+LABEL org.opencontainers.image.description="${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}/${RUN_CMD}:${GIT_TAG}-${GIT_REV}_${BUILD_ARCH}"
 
 # runtime dependencies
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \

--- a/Dockerfile.gmmat
+++ b/Dockerfile.gmmat
@@ -4,6 +4,19 @@ ARG BASE
 # BASE LAYER
 FROM $BASE as base
 
+# build-args
+ARG BASE
+ARG RUN_CMD
+ARG GIT_TAG
+ARG GIT_REV
+ARG BUILD_ARCH
+ARG BUILD_REPO
+
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="$BASE"
+LABEL org.opencontainers.image.description="${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}/${RUN_CMD}:${GIT_TAG}-${GIT_REV}_${BUILD_ARCH}"
+
 # shared builder and runtime dependencies
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 	apt -y install --no-install-recommends --no-install-suggests \
@@ -40,8 +53,10 @@ RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 
 
 # install GMMAT
-RUN Rscript -e 'install.packages("CompQuadForm")' && \
-    Rscript -e 'remotes::install_github("hihg-um/GMMAT", dependencies=FALSE)'
+RUN 	Rscript -e 'install.packages("CompQuadForm")' && \
+	Rscript -e 'remotes::install_github("smgogarten/SeqVarTools")' && \
+	Rscript -e 'remotes::install_github("smgogarten/SeqArray")' && \
+	Rscript -e 'remotes::install_github("hihg-um/GMMAT", dependencies=FALSE)'
 # ------------------------------------------------------------------------------
 # RUNTIME LAYER
 FROM base

--- a/Dockerfile.prosper
+++ b/Dockerfile.prosper
@@ -14,7 +14,19 @@ RUN git clone https://github.com/hihg-um/PROSPER.git
 # ------------------------------------------------------------------------------
 # RUNTIME LAYER
 FROM $BASE
+
+# build-args
+ARG BASE
 ARG RUN_CMD
+ARG GIT_TAG
+ARG GIT_REV
+ARG BUILD_ARCH
+ARG BUILD_REPO
+
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="$BASE"
+LABEL org.opencontainers.image.description="${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}/${RUN_CMD}:${GIT_TAG}-${GIT_REV}_${BUILD_ARCH}"
 
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 	apt -y install --no-install-recommends --no-install-suggests \

--- a/Dockerfile.prsice
+++ b/Dockerfile.prsice
@@ -22,7 +22,19 @@ RUN git clone --depth 1 https://github.com/choishingwan/PRSice.git && \
 # ------------------------------------------------------------------------------
 # RUNTIME LAYER
 FROM $BASE
+
+# build-args
+ARG BASE
 ARG RUN_CMD
+ARG GIT_TAG
+ARG GIT_REV
+ARG BUILD_ARCH
+ARG BUILD_REPO
+
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="$BASE"
+LABEL org.opencontainers.image.description="${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}/${RUN_CMD}:${GIT_TAG}-${GIT_REV}_${BUILD_ARCH}"
 
 # runtime only dependencies
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \

--- a/Dockerfile.saige
+++ b/Dockerfile.saige
@@ -4,9 +4,23 @@ ARG BASE
 # BASE LAYER
 FROM $BASE as base
 
+# build-args
+ARG BASE
+ARG RUN_CMD
+ARG GIT_TAG
+ARG GIT_REV
+ARG BUILD_ARCH
+ARG BUILD_REPO
+
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="$BASE"
+LABEL org.opencontainers.image.description="${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}/${RUN_CMD}:${GIT_TAG}-${GIT_REV}_${BUILD_ARCH}"
+
 # shared builder and runtime dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
 	apt-get install -y --no-install-recommends --no-install-suggests \
+	libsuperlu6 \
 	r-cran-data.table r-cran-lattice r-cran-matrix \
 	r-cran-optparse r-cran-rcpp r-cran-rcppparallel \
 	r-cran-rhpcblasctl \
@@ -44,21 +58,7 @@ RUN R CMD INSTALL SAIGE
 # ------------------------------------------------------------------------------
 # RUNTIME LAYER
 FROM base
-ARG RUN_CMD
-
-ENV LC_ALL C.UTF-8
-ENV LANG C.UTF-8
-ENV OMP_NUM_THREADS=1
-
-# runtime only dependencies
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
-	apt-get install -y --no-install-recommends --no-install-suggests \
-	libsuperlu6 \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& rm -rf /tmp/*
-
 COPY --chmod=0555 --from=builder /SAIGE/extdata/*.R /usr/local/bin/
-
 COPY --from=builder /usr/local/lib/R /usr/local/lib/R
 
 ARG TEST="/test.sh"

--- a/Dockerfile.seqmeta
+++ b/Dockerfile.seqmeta
@@ -10,10 +10,23 @@ RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 	make r-base r-base-dev \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /tmp/*
+
 #------------------------------------------------------------------------------
 # RUNTIME LAYER
 FROM base
+
+# build-args
+ARG BASE
 ARG RUN_CMD
+ARG GIT_TAG
+ARG GIT_REV
+ARG BUILD_ARCH
+ARG BUILD_REPO
+
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="$base"
+LABEL org.opencontainers.image.description="${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}/${RUN_CMD}:${GIT_TAG}-${GIT_REV}_${BUILD_ARCH}"
 
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 	apt -y install --no-install-recommends --no-install-suggests \


### PR DESCRIPTION
 - the base package is the runtime environment; no additional packages are needed for the release build
 - the builder container is discarded, no cleanups needed
 - the release container does not need a build-time name; the release tag supersedes