### PR TITLE
Label improvements and build-cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,21 +9,6 @@ ARG GIT_REPO
 ARG GIT_TAG
 ARG GIT_REV
 ARG BUILD_REPO
-ARG BUILD_TIME
-
-LABEL org.opencontainers.image.authors="kms309@miami.edu,sxd1425@miami.edu"
-LABEL org.opencontainers.image.base.digest=""
-LABEL org.opencontainers.image.base.name="$BASE"
-LABEL org.opencontainers.image.created="$BUILD_TIME"
-LABEL org.opencontainers.image.description="HIHG Base Image: R"
-LABEL org.opencontainers.image.licenses="GPL-2.0"
-LABEL org.opencontainers.image.ref.name="R base"
-LABEL org.opencontainers.image.revision="${GIT_REV}"
-LABEL org.opencontainers.image.source="https://${GIT_REPO}"
-LABEL org.opencontainers.image.title="Genomics Analysis Tools in R"
-LABEL org.opencontainers.image.url="${BUILD_REPO}"
-LABEL org.opencontainers.image.vendor="The Hussman Institute for Human Genomics, The University of Miami Miller School of Medicine"
-LABEL org.opencontainers.image.version="${GIT_TAG}"
 
 ENV TZ="UTC"
 
@@ -32,4 +17,17 @@ RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 	apt-utils bzip2 curl make\
 	r-base r-base-dev && \
 	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+LABEL org.opencontainers.image.authors="kms309@miami.edu,sxd1425@miami.edu"
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="$BASE"
+LABEL org.opencontainers.image.description="Genomics Analysis R Tools base container"
+LABEL org.opencontainers.image.licenses="GPL-2.0"
+LABEL org.opencontainers.image.ref.name="R base"
+LABEL org.opencontainers.image.revision="${GIT_REV}"
+LABEL org.opencontainers.image.source="https://${GIT_REPO}"
+LABEL org.opencontainers.image.title="HIHG: R Library container base image"
+LABEL org.opencontainers.image.url="${BUILD_REPO}"
+LABEL org.opencontainers.image.vendor="The Hussman Institute for Human Genomics, The University of Miami Miller School of Medicine"
+LABEL org.opencontainers.image.version="${GIT_TAG}"
 # ------------------------------------------------------------------------------

--- a/Dockerfile.genesis
+++ b/Dockerfile.genesis
@@ -8,10 +8,7 @@ FROM $BASE
 ARG BASE
 ARG RUN_CMD
 ARG BUILD_REPO
-
-LABEL org.opencontainers.image.base.name="${BASE}"
-LABEL org.opencontainers.image.description="R library: ${RUN_CMD}"
-LABEL org.opencontainers.image.url="${BUILD_REPO}"
+ARG BUILD_TIME
 
 # runtime dependencies
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
@@ -39,6 +36,12 @@ RUN Rscript -e 'install.packages(c("formula.tools", \
 		"quantsmooth", "SeqArray", "SeqVarTools", "SNPRelate"))' && \
 	Rscript -e 'BiocManager::install("GENESIS")'
 
-ARG TEST="/test.sh"
-COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
+
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="${BASE}"
+LABEL org.opencontainers.image.created="${BUILD_TIME}"
+LABEL org.opencontainers.image.description="Genesis R library and dependencies"
+LABEL org.opencontainers.image.title="HIHG: ${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}"
 # ------------------------------------------------------------------------------

--- a/Dockerfile.gmmat
+++ b/Dockerfile.gmmat
@@ -4,16 +4,6 @@ ARG BASE
 # BASE LAYER
 FROM $BASE as base
 
-# build-args
-ARG BASE
-ARG RUN_CMD
-ARG BUILD_REPO
-
-LABEL org.opencontainers.image.base.digest=""
-LABEL org.opencontainers.image.base.name="${BASE}"
-LABEL org.opencontainers.image.description="R library: ${RUN_CMD}"
-LABEL org.opencontainers.image.url="${BUILD_REPO}"
-
 # shared builder and runtime dependencies
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 	apt -y install --no-install-recommends --no-install-suggests \
@@ -57,10 +47,20 @@ RUN 	Rscript -e 'install.packages("CompQuadForm")' && \
 # ------------------------------------------------------------------------------
 # RUNTIME LAYER
 FROM base
+
+# build-args
+ARG BASE
 ARG RUN_CMD
+ARG BUILD_REPO
+ARG BUILD_TIME
 
 COPY --from=builder /usr/local/lib/R /usr/local/lib/R
+COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
-ARG TEST="/test.sh"
-COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="${BASE}"
+LABEL org.opencontainers.image.created="${BUILD_TIME}"
+LABEL org.opencontainers.image.description="GMMAT R library and dependencies"
+LABEL org.opencontainers.image.title="HIHG: ${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}"
 # ------------------------------------------------------------------------------

--- a/Dockerfile.prosper
+++ b/Dockerfile.prosper
@@ -19,10 +19,7 @@ FROM $BASE
 ARG BASE
 ARG RUN_CMD
 ARG BUILD_REPO
-
-LABEL org.opencontainers.image.base.name="${BASE}"
-LABEL org.opencontainers.image.description="R library: ${RUN_CMD}"
-LABEL org.opencontainers.image.url="${BUILD_REPO}"
+ARG BUILD_TIME
 
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 	apt -y install --no-install-recommends --no-install-suggests \
@@ -40,7 +37,12 @@ RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 RUN Rscript -e 'install.packages(c("bigassertr", "bigreadr", "cvAUC", "SuperLearner"))'
 
 COPY --chmod=0555 --from=builder /PROSPER/scripts /usr/local/bin
+COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
-ARG TEST="/test.sh"
-COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="${BASE}"
+LABEL org.opencontainers.image.created="$BUILD_TIME"
+LABEL org.opencontainers.image.description="PROSPER R library and dependencies"
+LABEL org.opencontainers.image.title="HIHG: ${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}"
 # ------------------------------------------------------------------------------

--- a/Dockerfile.prsice
+++ b/Dockerfile.prsice
@@ -27,10 +27,7 @@ FROM $BASE
 ARG BASE
 ARG RUN_CMD
 ARG BUILD_REPO
-
-LABEL org.opencontainers.image.base.name="${BASE}"
-LABEL org.opencontainers.image.description="R library: ${RUN_CMD}"
-LABEL org.opencontainers.image.url="${BUILD_REPO}"
+ARG BUILD_TIME
 
 # runtime only dependencies
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
@@ -43,6 +40,12 @@ RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 COPY --chmod=0555 --from=builder /PRSice/bin/PRSice /usr/local/bin/PRSice
 COPY --chmod=0555 --from=builder /PRSice/PRSice.R /usr/local/bin/PRSice.R
 
-ARG TEST="/test.sh"
-COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
+
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="${BASE}"
+LABEL org.opencontainers.image.created="${BUILD_TIME}"
+LABEL org.opencontainers.image.description="PRSice R library and dependencies"
+LABEL org.opencontainers.image.title="HIHG: ${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}"
 # ------------------------------------------------------------------------------

--- a/Dockerfile.saige
+++ b/Dockerfile.saige
@@ -4,15 +4,6 @@ ARG BASE
 # BASE LAYER
 FROM $BASE as base
 
-# build-args
-ARG BASE
-ARG RUN_CMD
-ARG BUILD_REPO
-
-LABEL org.opencontainers.image.base.name="${BASE}"
-LABEL org.opencontainers.image.description="R library: ${RUN_CMD}"
-LABEL org.opencontainers.image.url="${BUILD_REPO}"
-
 # shared builder and runtime dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
 	apt-get install -y --no-install-recommends --no-install-suggests \
@@ -54,9 +45,21 @@ RUN R CMD INSTALL SAIGE
 # ------------------------------------------------------------------------------
 # RUNTIME LAYER
 FROM base
+
+ARG BASE
+ARG RUN_CMD
+ARG BUILD_REPO
+ARG BUILD_TIME
+
 COPY --chmod=0555 --from=builder /SAIGE/extdata/*.R /usr/local/bin/
 COPY --from=builder /usr/local/lib/R /usr/local/lib/R
 
-ARG TEST="/test.sh"
-COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
+
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="${BASE}"
+LABEL org.opencontainers.image.created="${BUILD_TIME}"
+LABEL org.opencontainers.image.description="SAIGE R library and dependencies"
+LABEL org.opencontainers.image.title="HIHG: ${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}"
 # ------------------------------------------------------------------------------

--- a/Dockerfile.seqmeta
+++ b/Dockerfile.seqmeta
@@ -4,17 +4,6 @@ ARG BASE
 # BASE LAYER
 FROM ubuntu:22.04 as base
 
-# build-args
-ARG BASE
-ARG RUN_CMD
-ARG BUILD_REPO
-
-LABEL org.opencontainers.image.base.digest=""
-LABEL org.opencontainers.image.base.name="$BASE"
-LABEL org.opencontainers.image.description="HIHG ${RUN_CMD}"
-LABEL org.opencontainers.image.url="${BUILD_REPO}"
-
-# builder only dependencies
 RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 	apt -y install --no-install-recommends --no-install-suggests \
 	make r-base r-base-dev \
@@ -28,10 +17,8 @@ FROM base
 # build-args
 ARG BASE
 ARG RUN_CMD
-ARG GIT_TAG
-ARG GIT_REV
-ARG BUILD_ARCH
 ARG BUILD_REPO
+ARG BUILD_TIME
 
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="$base"
@@ -48,6 +35,12 @@ RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
 RUN Rscript -e 'install.packages(c("bdsmatrix", "CompQuadForm", "coxme"))' && \ 
 	Rscript -e 'remotes::install_github("DavisBrian/seqMeta")'
 
-ARG TEST="/test.sh"
-COPY --chmod=0555 src/test/$RUN_CMD.sh ${TEST}
+COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
+
+LABEL org.opencontainers.image.base.digest=""
+LABEL org.opencontainers.image.base.name="$BASE"
+LABEL org.opencontainers.image.created="${BUILD_TIME}"
+LABEL org.opencontainers.image.description="SeqMeta R library and dependencies"
+LABEL org.opencontainers.image.title="HIHG: ${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}"
 # ------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 GIT_REPO := $(shell git remote get-url origin | sed 's,git@,,' | sed 's,:,/,')
 GIT_REPO_TAIL := $(shell basename $(GIT_REPO) | sed 's/.git//' | \
 			sed 's/docker-//')
-GIT_TAG_HEAD ?= $(shell git describe --exact-match --tags --dirty)
+GIT_TAG_HEAD ?= $(shell git describe --exact-match --tags --dirty 2>/dev/null)
 GIT_TAG_LAST ?= $(shell git describe --abbrev=0 --always --tags)
 
 ifeq ($(GIT_TAG_HEAD),$(GIT_TAG_LAST))
@@ -82,6 +82,7 @@ $(TOOLS):
 		--build-arg BASE=$(DOCKER_BASE) \
 		--build-arg RUN_CMD=$@ \
 		--build-arg BUILD_REPO=$(DOCKER_REPO)/$@:$(DOCKER_TAG) \
+		--build-arg BUILD_TIME=$(DOCKER_BUILD_TIME) \
 		.
 	$(if $(GIT_LATEST), \
 		@docker tag \
@@ -96,7 +97,6 @@ docker_base:
 		--build-arg GIT_REV=$(GIT_REV) \
 		--build-arg GIT_TAG=$(GIT_TAG) \
 		--build-arg BUILD_REPO=$(DOCKER_BASE) \
-		--build-arg BUILD_TIME=$(DOCKER_BUILD_TIME) \
 		.
 	@docker inspect $(DOCKER_BASE)
 


### PR DESCRIPTION
 - don't time-stamp the base layer to avoid rebuilds
 - label build time and title in production container images
 - simplify test-script installation