### PR TITLE
Build and label update

### DIFF
--- a/Dockerfile.genesis
+++ b/Dockerfile.genesis
@@ -2,17 +2,13 @@
 ARG BASE
 # ------------------------------------------------------------------------------
 # RUNTIME LAYER
-FROM $BASE
-
-# build-args
+FROM $BASE as base
 ARG BASE
-ARG RUN_CMD
-ARG BUILD_REPO
-ARG BUILD_TIME
 
 # runtime dependencies
 RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 	--no-install-recommends --no-install-suggests \
+		liblzma5 \
 		r-cran-data.table \
 		r-cran-formatr \
 		r-cran-futile.logger \
@@ -59,12 +55,27 @@ RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 	&& \
 	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
+FROM base as builder
+
+RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
+	--no-install-recommends --no-install-suggests \
+		liblzma-dev
+
 RUN Rscript -e 'install.packages(c("formula.tools", \
 		"GWASExactHW", "logistf", "operator.tools"))' && \
 	Rscript -e 'BiocManager::install(c("gdsfmt", "GWASTools", \
 		"quantsmooth", "SeqArray", "SeqVarTools", "SNPRelate"))' && \
 	Rscript -e 'BiocManager::install("GENESIS")'
 
+FROM base
+
+# build-args
+ARG BASE
+ARG RUN_CMD
+ARG BUILD_REPO
+ARG BUILD_TIME
+
+COPY --chmod=0555 --from=builder /usr/local/lib/R /usr/local/lib/R
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
 LABEL org.opencontainers.image.base.digest=""

--- a/Dockerfile.gmmat
+++ b/Dockerfile.gmmat
@@ -5,32 +5,19 @@ ARG BASE
 FROM $BASE as base
 
 # shared builder and runtime dependencies
-RUN apt -y update -qq && apt -y upgrade && DEBIAN_FRONTEND=noninteractive \
-	apt -y install --no-install-recommends --no-install-suggests \
-	r-cran-codetools r-cran-data.table r-cran-foreach \
-	r-cran-iterators r-cran-lattice r-cran-matrix \
-	r-cran-rcpp r-cran-rcpparmadillo \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& rm -rf /tmp/*
-# ------------------------------------------------------------------------------
-# BUILDER LAYER
-FROM base as builder
-
-# builder only dependencies
-RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
+RUN apt -y update -qq && apt -y upgrade && \
+	DEBIAN_FRONTEND=noninteractive apt -y install \
 	--no-install-recommends --no-install-suggests \
-		libdeflate-dev \
-		libzstd-dev \
-		liblzma-dev \
-		r-cran-remotes \
-		r-cran-biocmanager \
-		r-cran-devtools \
+		libdeflate0 \
+		liblzma5 \
+		libzstd1 \
 		r-cran-data.table \
-		r-cran-domc \
 		r-cran-foreach \
+		r-cran-iterators \
+		r-cran-lattice \
 		r-cran-matrix \
+		r-cran-rcpp \
 		r-cran-rcpparmadillo \
-		r-cran-testthat \
 		r-bioc-biobase \
 		r-bioc-biocgenerics \
 		r-bioc-biocparallel \
@@ -39,6 +26,23 @@ RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 		r-bioc-genomeinfodb \
 		r-bioc-genomicranges \
 		r-bioc-s4vectors \
+	&& \
+	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
+# ------------------------------------------------------------------------------
+# BUILDER LAYER
+FROM base as builder
+
+# builder only dependencies
+RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
+	--no-install-recommends --no-install-suggests \
+		libdeflate-dev \
+		liblzma-dev \
+		libzstd-dev \
+		r-cran-codetools \
+		r-cran-devtools \
+		r-cran-domc \
+		r-cran-remotes \
+		r-cran-testthat \
 	&& \
 	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
 

--- a/Dockerfile.prsice
+++ b/Dockerfile.prsice
@@ -1,45 +1,42 @@
 # SPDX-License-Identifier: GPL-2.0
 ARG BASE
-# ------------------------------------------------------------------------------
-# BUILDER LAYER
-FROM $BASE as builder
-
-# builder only dependencies
-# PRSice currently only compiles on Ubuntu<20.04
+FROM $BASE as base
 RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 	--no-install-recommends --no-install-suggests \
-		cmake \
-		git \
 		libpthread-stubs0-dev \
-		zlib1g-dev \
-	&& \
-	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
-
-RUN git clone --depth 1 https://github.com/choishingwan/PRSice.git && \
-	cd PRSice && \
-	mkdir build && \
-	cd build && \
-	cmake ../ && \
-	make
-# ------------------------------------------------------------------------------
-# RUNTIME LAYER
-FROM $BASE
-
-# build-args
-ARG BASE
-ARG RUN_CMD
-ARG BUILD_REPO
-ARG BUILD_TIME
-
-# runtime only dependencies
-RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
-	--no-install-recommends --no-install-suggests \
+		zlib1g \
 		r-cran-data.table \
 		r-cran-ggplot2 \
 		r-cran-optparse \
 		r-cran-rcolorbrewer \
 	&& \
 	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# ------------------------------------------------------------------------------
+# BUILDER LAYER
+FROM base as builder
+
+# builder only dependencies
+RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
+	--no-install-recommends --no-install-suggests \
+		cmake \
+		git \
+		zlib1g-dev \
+	&& \
+	apt -y clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN git clone --depth 1 https://github.com/choishingwan/PRSice.git && \
+	cd PRSice && mkdir build && cd build && \
+	cmake ../ && make
+# ------------------------------------------------------------------------------
+# RUNTIME LAYER
+FROM base
+
+# build-args
+ARG BASE
+ARG RUN_CMD
+ARG BUILD_REPO
+ARG BUILD_TIME
 
 COPY --chmod=0555 --from=builder /PRSice/bin/PRSice /usr/local/bin/PRSice
 COPY --chmod=0555 --from=builder /PRSice/PRSice.R /usr/local/bin/PRSice.R

--- a/Dockerfile.saige
+++ b/Dockerfile.saige
@@ -4,10 +4,15 @@ ARG BASE
 # BASE LAYER
 FROM $BASE as base
 
-# shared builder and runtime dependencies
+# runtime dependencies
 RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 	--no-install-recommends --no-install-suggests \
+		liblzma5 \
+		libsavvy-dev \
+		libshrinkwrap-dev \
 		libsuperlu6 \
+		libzstd1 \
+		zlib1g \
 		r-cran-data.table \
 		r-cran-lattice \
 		r-cran-matrix \
@@ -28,8 +33,6 @@ RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 		git \
 		g++ \
 		liblzma-dev \
-		libsavvy-dev \
-		libshrinkwrap-dev \
 		libsuperlu-dev \
 		libzstd-dev \
 		zlib1g-dev \


### PR DESCRIPTION
 - place each package on its own line to facilitate diffs and dependency simplification
 - clean after package install (except on discarded builder)
 - install runtime dependencies in the base image first, so they can be discovered by any build configuration or dependency check (this in some cases avoids building vendored libraries)
 - include the runtime libraries in the base image where -dev libraries are included in the builder