### PR TITLE
Don't upgrade from the application builder, the base image has upgraded

### DIFF
--- a/Dockerfile.genesis
+++ b/Dockerfile.genesis
@@ -141,6 +141,8 @@ ARG BUILD_TIME
 COPY --from=builder /usr/local/lib/R /usr/local/lib/R
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
+ENTRYPOINT [ "Rscript" ]
+
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="${BASE}"
 LABEL org.opencontainers.image.created="${BUILD_TIME}"

--- a/Dockerfile.gmmat
+++ b/Dockerfile.gmmat
@@ -129,6 +129,8 @@ RUN apt -y remove \
 #  'tidyselect', 'withr', 'zlibbioc', 'KernSmooth', 'lattice',
 #  'nlme', 'survival'
 
+ENTRYPOINT [ "Rscript" ]
+
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="${BASE}"
 LABEL org.opencontainers.image.created="${BUILD_TIME}"

--- a/Dockerfile.gmmat
+++ b/Dockerfile.gmmat
@@ -5,8 +5,7 @@ ARG BASE
 FROM $BASE as base
 
 # shared builder and runtime dependencies
-RUN apt -y update -qq && apt -y upgrade && \
-	DEBIAN_FRONTEND=noninteractive apt -y install \
+RUN apt -y update -qq && DEBIAN_FRONTEND=noninteractive apt -y install \
 	--no-install-recommends --no-install-suggests \
 		libbz2-1.0 \
 		libdeflate0 \

--- a/Dockerfile.prosper
+++ b/Dockerfile.prosper
@@ -59,9 +59,11 @@ ARG RUN_CMD
 ARG BUILD_REPO
 ARG BUILD_TIME
 
-COPY --chmod=0555 --from=builder /usr/local/lib/R /usr/local/lib/R
+COPY --from=builder /usr/local/lib/R /usr/local/lib/R
 COPY --chmod=0555 --from=builder /PROSPER/scripts /usr/local/bin
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
+
+ENTRYPOINT [ "Rscript" ]
 
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="${BASE}"

--- a/Dockerfile.prsice
+++ b/Dockerfile.prsice
@@ -43,6 +43,8 @@ COPY --chmod=0555 --from=builder /PRSice/bin/PRSice /usr/local/bin/PRSice
 COPY --chmod=0555 --from=builder /PRSice/PRSice.R /usr/local/bin/PRSice.R
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 
+ENTRYPOINT [ "Rscript" ]
+
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="${BASE}"
 LABEL org.opencontainers.image.created="${BUILD_TIME}"

--- a/Dockerfile.saige
+++ b/Dockerfile.saige
@@ -71,9 +71,11 @@ ARG RUN_CMD
 ARG BUILD_REPO
 ARG BUILD_TIME
 
-COPY --chmod=0555 --from=builder /SAIGE/extdata/*.R /usr/local/bin/
 COPY --from=builder /usr/local/lib/R /usr/local/lib/R
+COPY --chmod=0555 --from=builder /SAIGE/extdata/*.R /usr/local/bin/
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
+
+ENTRYPOINT [ "Rscript" ]
 
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="${BASE}"

--- a/Dockerfile.seqmeta
+++ b/Dockerfile.seqmeta
@@ -38,8 +38,10 @@ ARG RUN_CMD
 ARG BUILD_REPO
 ARG BUILD_TIME
 
-COPY --chmod=0555 --from=builder /usr/local/lib/R /usr/local/lib/R
+COPY --from=builder /usr/local/lib/R /usr/local/lib/R
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
+
+ENTRYPOINT [ "Rscript" ]
 
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="$BASE"

--- a/Dockerfile.staar
+++ b/Dockerfile.staar
@@ -202,6 +202,8 @@ COPY --from=builder /usr/local/lib/R /usr/local/lib/R
 COPY --chmod=0555 src/test/${RUN_CMD}.sh /test.sh
 COPY --chmod=0555 src/test/${RUN_CMD}.R /
 
+ENTRYPOINT [ "Rscript" ]
+
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="${BASE}"
 LABEL org.opencontainers.image.created="${BUILD_TIME}"


### PR DESCRIPTION
The base image runs a generic OS upgrade. Once that is complete, any application layer installing packages simply needs to run apt -y update to ensure that additional packages are latest versions.

This might create a race if the upstream source lists are updated during a build, however that scenario is quite unlikely, and will either result in some packages being newer than others, or possibly a transient package-not-found build failure.

In the first scenario, that can be detected, and in the second scenario, it serves as a warning and requires a manual kick.

The possible occurrence of that first scenario is further reduced by implementing:  https://github.com/hihg-um/docker-r/issues/36